### PR TITLE
Enforce numpy-style docstrings via ruff pydocstyle

### DIFF
--- a/pyPowerUp/mde.py
+++ b/pyPowerUp/mde.py
@@ -37,8 +37,7 @@ def mde_bcra3f2(
     r22: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Three-Level Blocked (Fixed) Cluster-level Random Assignment Design,
-    Treatment at Level 2
+    """Calculate the Minimum Detectable Effect of a Three-Level Blocked (Fixed) Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -116,8 +115,7 @@ def mde_bcra3r2(
     r2t3: float = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Three-Level Blocked Cluster-level Random Assignment Design,
-    Treatment at Level 2
+    """Calculate the Minimum Detectable Effect of a Three-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -206,8 +204,7 @@ def mde_bcra4f3(
     g3: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Four-Level Blocked (Fixed) Cluster-level Random Assignment Design,
-    Treatment at Level 3
+    """Calculate the Minimum Detectable Effect of a Four-Level Blocked (Fixed) Cluster-level Random Assignment Design, Treatment at Level 3.
 
     Parameters
     ----------
@@ -299,8 +296,7 @@ def mde_bcra4r2(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment
-    at Level 2
+    """Calculate the Minimum Detectable Effect of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -402,8 +398,7 @@ def mde_bcra4r3(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment
-     at Level 3
+    """Calculate the Minimum Detectable Effect of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 3.
 
     Parameters
     ----------
@@ -493,8 +488,7 @@ def mde_bira2c1(
     r21: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Two-Level Blocked (Constant Treatment Effect) Individual-level
-    Random Assignment Design, Treatment at Level 1
+    """Calculate the Minimum Detectable Effect of a Two-Level Blocked (Constant Treatment Effect) Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -560,8 +554,7 @@ def mde_bira2f1(
     r21: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Two-Level Blocked (Fixed) Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the Minimum Detectable Effect of a Two-Level Blocked (Fixed) Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -630,8 +623,7 @@ def mde_bira2r1(
     r2t2: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Two-Level Blocked Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the Minimum Detectable Effect of a Two-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -711,8 +703,7 @@ def mde_bira3r1(
     g3: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Three-Level Blocked Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the Minimum Detectable Effect of a Three-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -809,8 +800,7 @@ def mde_bira4r1(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Four-Level Blocked Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the Minimum Detectable Effect of a Four-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -908,8 +898,7 @@ def mde_cra2r2(
     r22: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Two-level Cluster-randomized Trials to Detect Main, Moderation and
-    Mediation Effects
+    """Calculate the Minimum Detectable Effect of a Two-level Cluster-randomized Trials to Detect Main, Moderation and Mediation Effects.
 
     Parameters
     ----------
@@ -984,8 +973,7 @@ def mde_cra3r3(
     r23: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Three-level Cluster-randomized Trials to Detect Main, Moderation,
-    and Mediation Effects
+    """Calculate the Minimum Detectable Effect of a Three-level Cluster-randomized Trials to Detect Main, Moderation, and Mediation Effects.
 
     Parameters
     ----------
@@ -1073,7 +1061,7 @@ def mde_cra4r4(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Four-Level Cluster-randomized Trial
+    """Calculate the Minimum Detectable Effect of a Four-Level Cluster-randomized Trial.
 
     Parameters
     ----------
@@ -1159,7 +1147,7 @@ def mde_ira1r1(
     r21: float = 0,
     print_pretty: bool = True,
 ) -> dict[str, Any]:
-    """Calculates the Minimum Detectable Effect of a Individual-level Random Assignment Design
+    """Calculate the Minimum Detectable Effect of a Individual-level Random Assignment Design.
 
     Parameters
     ----------

--- a/pyPowerUp/power.py
+++ b/pyPowerUp/power.py
@@ -36,8 +36,7 @@ def power_bcra3f2(
     r22: float = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Three-Level Blocked (Fixed) Cluster-level Random Assignment Design,
-    Treatment at Level 2
+    """Calculate the power of a Three-Level Blocked (Fixed) Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -70,7 +69,6 @@ def power_bcra3f2(
     -------
     The power of the test
     """
-
     df = ceil(K * (J - 2) - g2)
     sse = sqrt(rho2 * (1 - r22) / (p * (1 - p) * J * K) + (1 - rho2) * (1 - r21) / (p * (1 - p) * J * K * n))
     power = _power(effect_size, alpha, sse, df, two_tailed)
@@ -115,8 +113,7 @@ def power_bcra3r2(
     r2t3: float = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Three-Level Blocked Cluster-level Random Assignment Design,
-    Treatment at Level 2
+    """Calculate the power of a Three-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -204,8 +201,7 @@ def power_bcra4f3(
     g3: int = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Four-Level Blocked (Fixed) Cluster-level Random Assignment Design,
-    Treatment at Level 3
+    """Calculate the power of a Four-Level Blocked (Fixed) Cluster-level Random Assignment Design, Treatment at Level 3.
 
     Parameters
     ----------
@@ -296,8 +292,7 @@ def power_bcra4r2(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment
-    at Level 2
+    """Calculate the power of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -398,8 +393,7 @@ def power_bcra4r3(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment
-     at Level 3
+    """Calculate the power of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 3.
 
     Parameters
     ----------
@@ -488,8 +482,7 @@ def power_bira2c1(
     r21: float = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Two-Level Blocked (Constant Treatment Effect) Individual-level
-    Random Assignment Design, Treatment at Level 1
+    """Calculate the power of a Two-Level Blocked (Constant Treatment Effect) Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -554,8 +547,7 @@ def power_bira2f1(
     r21: float = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Two-Level Blocked (Fixed) Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the power of a Two-Level Blocked (Fixed) Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -623,8 +615,7 @@ def power_bira2r1(
     r2t2: float = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Two-Level Blocked Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the power of a Two-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -703,7 +694,7 @@ def power_bira3r1(
     g3: int = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Three-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1
+    """Calculate the power of a Three-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -799,8 +790,7 @@ def power_bira4r1(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Four-Level Blocked Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the power of a Four-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -897,8 +887,7 @@ def power_cra2r2(
     r22: float = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Two-level Cluster-randomized Trials to Detect Main, Moderation and
-    Mediation Effects
+    """Calculate the power of a Two-level Cluster-randomized Trials to Detect Main, Moderation and Mediation Effects.
 
     Parameters
     ----------
@@ -972,8 +961,7 @@ def power_cra3r3(
     r23: float = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Three-level Cluster-randomized Trials to Detect Main, Moderation,
-    and Mediation Effects
+    """Calculate the power of a Three-level Cluster-randomized Trials to Detect Main, Moderation, and Mediation Effects.
 
     Parameters
     ----------
@@ -1060,7 +1048,7 @@ def power_cra4r4(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Four-Level Cluster-randomized Trial
+    """Calculate the power of a Four-Level Cluster-randomized Trial.
 
     Parameters
     ----------
@@ -1145,7 +1133,7 @@ def power_ira1r1(
     r21: float = 0,
     print_pretty: bool = True,
 ) -> float:
-    """Calculates the power of a Individual-level Random Assignment Design
+    """Calculate the power of a Individual-level Random Assignment Design.
 
     Parameters
     ----------

--- a/pyPowerUp/sample_size.py
+++ b/pyPowerUp/sample_size.py
@@ -39,8 +39,7 @@ def sample_size_bcra3f2(
     r22: float = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the minimum sample size of a Three-Level Blocked (Fixed) Cluster-level Random Assignment Design,
-    Treatment at Level 2
+    """Calculate the minimum sample size of a Three-Level Blocked (Fixed) Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -116,8 +115,7 @@ def sample_size_bcra3r2(
     r2t3: float = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the power of a Three-Level Blocked Cluster-level Random Assignment Design,
-    Treatment at Level 2
+    """Calculate the power of a Three-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -202,8 +200,7 @@ def sample_size_bcra4f3(
     r23: float = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the minimum sample size of a Four-Level Blocked (Fixed) Cluster-level Random Assignment Design,
-    Treatment at Level 3
+    """Calculate the minimum sample size of a Four-Level Blocked (Fixed) Cluster-level Random Assignment Design, Treatment at Level 3.
 
     Parameters
     ----------
@@ -291,8 +288,7 @@ def sample_size_bcra4r2(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the minimum sample size of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment
-    at Level 2
+    """Calculate the minimum sample size of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 2.
 
     Parameters
     ----------
@@ -390,8 +386,7 @@ def sample_size_bcra4r3(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the minimum sample size of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment
-     at Level 3
+    """Calculate the minimum sample size of a Four-Level Blocked Cluster-level Random Assignment Design, Treatment at Level 3.
 
     Parameters
     ----------
@@ -477,8 +472,7 @@ def sample_size_bira2c1(
     r21: float = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the minimum sample size of a Two-Level Blocked Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the minimum sample size of a Two-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -540,8 +534,7 @@ def sample_size_bira2f1(
     r21: float = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the minimum sample size of a Two-Level Blocked (Fixed) Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the minimum sample size of a Two-Level Blocked (Fixed) Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -606,8 +599,7 @@ def sample_size_bira2r1(
     r2t2: float = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the minimum sample size of a Two-Level Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the minimum sample size of a Two-Level Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -683,8 +675,7 @@ def sample_size_bira3r1(
     g3: int = 0,
     print_pretty: bool = True,
 ) -> int | None:
-    """Calculates the minimum sample size of a Three-Level Blocked Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the minimum sample size of a Three-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -777,8 +768,7 @@ def sample_size_bira4r1(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> float | None:
-    """Calculates the minimum sample size of a Four-Level Blocked Individual-level Random Assignment Design,
-    Treatment at Level 1
+    """Calculate the minimum sample size of a Four-Level Blocked Individual-level Random Assignment Design, Treatment at Level 1.
 
     Parameters
     ----------
@@ -872,8 +862,7 @@ def sample_size_cra2r2(
     r22: float = 0,
     print_pretty: bool = True,
 ) -> float | None:
-    """Calculates the minimum sample size of a Two-level Cluster-randomized Trials to Detect Main, Moderation and
-    Mediation Effects
+    """Calculate the minimum sample size of a Two-level Cluster-randomized Trials to Detect Main, Moderation and Mediation Effects.
 
     Parameters
     ----------
@@ -944,8 +933,7 @@ def sample_size_cra3r3(
     r23: float = 0,
     print_pretty: bool = True,
 ) -> float | None:
-    """Calculates the minimum sample size of a Three-level Cluster-randomized Trials to Detect Main, Moderation,
-    and Mediation Effects
+    """Calculate the minimum sample size of a Three-level Cluster-randomized Trials to Detect Main, Moderation, and Mediation Effects.
 
     Parameters
     ----------
@@ -1029,7 +1017,7 @@ def sample_size_cra4r4(
     g4: int = 0,
     print_pretty: bool = True,
 ) -> float | None:
-    """Calculates the minimum sample size of a Four-Level Cluster-randomized Trial
+    """Calculate the minimum sample size of a Four-Level Cluster-randomized Trial.
 
     Parameters
     ----------
@@ -1111,7 +1099,7 @@ def sample_size_ira1r1(
     r21: float = 0,
     print_pretty: bool = True,
 ) -> float | None:
-    """Calculates the minimum sample size of a Individual-level Random Assignment Design
+    """Calculate the minimum sample size of a Individual-level Random Assignment Design.
 
     Parameters
     ----------

--- a/pyPowerUp/utils.py
+++ b/pyPowerUp/utils.py
@@ -1,3 +1,5 @@
+"""Internal helper functions for computing minimum detectable effect and statistical power."""
+
 from math import sqrt
 from typing import Any
 
@@ -6,7 +8,7 @@ from scipy.stats import t as t_dist
 
 
 def _mde(power: float, alpha: float, sse: float, df: int, two_tailed: bool) -> dict[str, Any]:
-    """Calculates the mde of the test
+    """Calculate the mde of the test.
 
     Parameters
     ----------
@@ -42,7 +44,7 @@ def _mde(power: float, alpha: float, sse: float, df: int, two_tailed: bool) -> d
 
 
 def _power(effect_size: float, alpha: float, sse: float, df: float, two_tailed: bool) -> float:
-    """Calculates the power of the test
+    """Calculate the power of the test.
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,16 +105,22 @@ select = [
     "ARG",    # flake8-unused-arguments
     "PTH",    # flake8-use-pathlib
     "RUF",    # Ruff-specific rules
+    "D",      # pydocstyle (numpy convention, see [tool.ruff.lint.pydocstyle])
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)
     "N803",   # argument name should be lowercase (conflicts with math conventions)
     "N806",   # variable in function should be lowercase (conflicts with math conventions)
     "N999",   # invalid module name (pyPowerUp is intentional branding)
+    "D104",   # missing docstring in public package (__init__.py)
+    "D105",   # missing docstring in magic method
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.lint.per-file-ignores]
-"test/*.py" = ["ARG"]
+"test/*.py" = ["ARG", "D"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
Enables ruff's pydocstyle (`D`) rules with the **numpy convention** and brings all public docstrings into compliance.

## Changes
- **`pyproject.toml`**: add `"D"` to `select`, set `convention = "numpy"`, ignore `D104`/`D105`, and disable `D` for `test/*`
- **Auto-fixed (45)**: `D400` trailing periods (×44) and `D202` (×1) via `ruff --fix`
- **Manual (80)**: `D401` (imperative mood, `Calculates` → `Calculate`) and `D205` (collapse two-line summaries to a single line + blank line before `Parameters`) across `mde.py`, `power.py`, `sample_size.py`; added a module docstring to `utils.py`

## Verification
- `ruff check .` → all checks passed (full rule set)
- `ruff format --check` → no drift
- All modules import successfully

Docstring-only changes — no code, type annotations, or section bodies touched.

> ⚠️ Enforcement is now active: new public functions without a numpy-style docstring will fail lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)